### PR TITLE
LITE-28216 Save user OID in PPRVersion.created_by

### DIFF
--- a/connect_ext_ppr/events.py
+++ b/connect_ext_ppr/events.py
@@ -70,7 +70,7 @@ class ConnectExtensionXvsEventsApplication(EventsApplicationBase):
     def handle_product_changed(self, request):
         '''
         Product change event: update or not the product version present
-        in the Deployment object. If Deployment object does not exists in
+        in the Deployment object. If Deployment object does not exist in
         db, create a new one.
         '''
         self.logger.info(f"Product {request['id']} changed.")

--- a/connect_ext_ppr/service.py
+++ b/connect_ext_ppr/service.py
@@ -130,7 +130,7 @@ def process_ppr_from_product_update(data, config, context, client, logger):
                 dep_qs = product.deployment.filter_by(account_id=context.account_id)
                 logger.info(f"Product version changed: {older_version} -> {data['version']}.")
                 for dep in dep_qs:
-                    create_ppr(ppr, context, dep, db, client, logger)
+                    create_ppr(ppr, context.user_id, dep, db, client, logger)
 
 
 def update_product(data, db, product, logger):
@@ -155,7 +155,7 @@ def get_ppr_new_version(db, deployment):
     return new_version
 
 
-def create_ppr(ppr, context, deployment, db, client, logger):
+def create_ppr(ppr, user_id, deployment, db, client, logger):
     file_data = ppr.file
     new_version = get_ppr_new_version(db, deployment)
     config_kwargs = {}
@@ -257,7 +257,7 @@ def create_ppr(ppr, context, deployment, db, client, logger):
             name=file_data.name,
             size=file_data.size,
             mime_type=file_data.mime_type,
-            created_by=context.user_id,
+            created_by=user_id,
         )
         db.add(file_instance)
         db.flush()
@@ -270,7 +270,7 @@ def create_ppr(ppr, context, deployment, db, client, logger):
             description=DESCRIPTION_TEMPLATE.format(description=description, summary=desc_summary),
             summary=summary,
             status=status,
-            created_by=context.user_id,
+            created_by=user_id,
             **config_kwargs,
         )
         db.set_verbose(new_ppr)

--- a/connect_ext_ppr/webapp.py
+++ b/connect_ext_ppr/webapp.py
@@ -14,8 +14,7 @@ from connect.eaas.core.decorators import (
     router,
     web_app,
 )
-from connect.eaas.core.inject.common import get_call_context, get_logger
-from connect.eaas.core.inject.models import Context
+from connect.eaas.core.inject.common import get_logger
 from connect.eaas.core.inject.synchronous import (
     get_installation,
     get_installation_client,
@@ -507,11 +506,12 @@ class ConnectExtensionXvsWebApplication(WebApplicationBase):
         db: VerboseBaseSession = Depends(get_db),
         installation: dict = Depends(get_installation),
         logger: Logger = Depends(get_logger),
-        context: Context = Depends(get_call_context),
+        request: Request = None,
     ):
         deployment = get_deployment_by_id(deployment_id, db, installation)
+        user_data = get_user_data_from_auth_token(request.headers['connect-auth'])
         ppr_version_instance, file_instance, configuration = create_ppr(
-            ppr_version, context, deployment, db, client, logger,
+            ppr_version, user_data['id'], deployment, db, client, logger,
         )
         return get_ppr_version_schema(ppr_version_instance, file_instance, configuration)
 

--- a/tests/api/test_configurations.py
+++ b/tests/api/test_configurations.py
@@ -93,6 +93,7 @@ def test_post_configuration(
     deployment_factory,
     media_response,
     configuration_json,
+    connect_auth_header,
     installation,
     api_client,
     dbsession,
@@ -116,10 +117,7 @@ def test_post_configuration(
             },
         },
         headers={
-            "connect-auth": (
-                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1Ijp7Im9pZCI6IlNVLTI5NS02ODktN"
-                "jI4IiwibmFtZSI6Ik5lcmkifX0.U_T6vuXnD293hcWNTJZ9QBViteNv8JXUL2gM0BezQ-k"
-            ),
+            "connect-auth": connect_auth_header,
         },
     )
     assert response.status_code == 201
@@ -155,6 +153,7 @@ def test_post_configuration_deactivate_previous(
     file,
     configuration,
     configuration_json,
+    connect_auth_header,
     installation,
     api_client,
     dbsession,
@@ -178,10 +177,7 @@ def test_post_configuration_deactivate_previous(
             },
         },
         headers={
-            "connect-auth": (
-                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1Ijp7Im9pZCI6IlNVLTI5NS02ODktN"
-                "jI4IiwibmFtZSI6Ik5lcmkifX0.U_T6vuXnD293hcWNTJZ9QBViteNv8JXUL2gM0BezQ-k"
-            ),
+            "connect-auth": connect_auth_header,
         },
     )
     assert response.status_code == 201
@@ -256,6 +252,7 @@ def test_post_configuration_invalid(
     deployment_factory,
     media_response,
     configuration_json,
+    connect_auth_header,
     installation,
     api_client,
     dbsession,
@@ -279,10 +276,7 @@ def test_post_configuration_invalid(
             },
         },
         headers={
-            "connect-auth": (
-                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1Ijp7Im9pZCI6IlNVLTI5NS02ODktN"
-                "jI4IiwibmFtZSI6Ik5lcmkifX0.U_T6vuXnD293hcWNTJZ9QBViteNv8JXUL2gM0BezQ-k"
-            ),
+            "connect-auth": connect_auth_header,
         },
     )
     assert response.status_code == 400

--- a/tests/api/test_pprs.py
+++ b/tests/api/test_pprs.py
@@ -173,6 +173,7 @@ def test_get_ppr_not_found(
 def test_upload_ppr(
     deployment_factory,
     file_factory,
+    connect_auth_header,
     installation,
     api_client,
     mocker,
@@ -203,6 +204,9 @@ def test_upload_ppr(
             },
             'description': 'What a lovely day',
         },
+        headers={
+            "connect-auth": connect_auth_header,
+        },
     )
     assert response.status_code == 201
     data = response.json()
@@ -223,7 +227,7 @@ def test_upload_ppr(
     }
     assert id[:6] == 'PPRFL-'
     assert isinstance(events['created']['at'], str)
-    assert events['created']['by'] == 'UR-000'
+    assert events['created']['by'] == 'SU-295-689-628'
 
     assert dbsession.query(PPRVersion).count() == 1
     assert dbsession.query(File).count() == 1
@@ -232,6 +236,7 @@ def test_upload_ppr(
 def test_upload_ppr_invalid(
     deployment_factory,
     file_factory,
+    connect_auth_header,
     installation,
     api_client,
     mocker,
@@ -261,6 +266,9 @@ def test_upload_ppr_invalid(
             },
             'description': 'What a lovely day',
         },
+        headers={
+            "connect-auth": connect_auth_header,
+        },
     )
     assert response.status_code == 201
     data = response.json()
@@ -285,13 +293,14 @@ def test_upload_ppr_invalid(
     }
     assert id[:6] == 'PPRFL-'
     assert isinstance(events['created']['at'], str)
-    assert events['created']['by'] == 'UR-000'
+    assert events['created']['by'] == 'SU-295-689-628'
 
 
 def test_post_ppr_new_version(
     deployment_factory,
     file_factory,
     ppr_version_factory,
+    connect_auth_header,
     installation,
     api_client,
     mocker,
@@ -325,6 +334,9 @@ def test_post_ppr_new_version(
             },
             'description': 'What a lovely day',
         },
+        headers={
+            "connect-auth": connect_auth_header,
+        },
     )
     assert response.status_code == 201
     data = response.json()
@@ -345,7 +357,7 @@ def test_post_ppr_new_version(
     }
     assert id[:6] == 'PPRFL-'
     assert isinstance(events['created']['at'], str)
-    assert events['created']['by'] == 'UR-000'
+    assert events['created']['by'] == 'SU-295-689-628'
 
     assert dbsession.query(PPRVersion).count() == 2
     assert dbsession.query(File).count() == 2
@@ -381,6 +393,7 @@ def test_post_ppr_wrong_deployment(
 def test_post_ppr_file_already_exists(
     deployment_factory,
     file_factory,
+    connect_auth_header,
     installation,
     api_client,
     dbsession,
@@ -411,6 +424,9 @@ def test_post_ppr_file_already_exists(
                 'mime_type': file.mime_type,
             },
         },
+        headers={
+            "connect-auth": connect_auth_header,
+        },
     )
     assert response.status_code == 400
     assert response.json() == {
@@ -424,6 +440,7 @@ def test_post_ppr_file_already_exists(
 def test_generate_ppr(
     deployment_factory,
     configuration_factory,
+    connect_auth_header,
     installation,
     api_client,
     mocker,
@@ -480,6 +497,9 @@ def test_generate_ppr(
         f'/api/deployments/{deployment.id}/pprs',
         installation=installation,
         json={},
+        headers={
+            "connect-auth": connect_auth_header,
+        },
     )
     assert response.status_code == 201
     data = response.json()
@@ -509,12 +529,13 @@ def test_generate_ppr(
     assert id[:6] == 'PPRFL-'
     assert isinstance(events['created']['at'], str)
     assert file_name[:23] == 'PPR_PRD-XXX-XXX-XXX_v1_'
-    assert events['created']['by'] == 'UR-000'
+    assert events['created']['by'] == 'SU-295-689-628'
     assert 10000 < file_size < 20000
 
 
 def test_generate_ppr_no_configuration(
     deployment_factory,
+    connect_auth_header,
     installation,
     api_client,
     mocker,
@@ -561,6 +582,9 @@ def test_generate_ppr_no_configuration(
         f'/api/deployments/{deployment.id}/pprs',
         installation=installation,
         json={},
+        headers={
+            "connect-auth": connect_auth_header,
+        },
     )
     assert response.status_code == 201
     data = response.json()
@@ -586,5 +610,5 @@ def test_generate_ppr_no_configuration(
     assert id[:6] == 'PPRFL-'
     assert isinstance(events['created']['at'], str)
     assert file_name[:23] == 'PPR_PRD-XXX-XXX-XXX_v1_'
-    assert events['created']['by'] == 'UR-000'
+    assert events['created']['by'] == 'SU-295-689-628'
     assert 10000 < file_size < 20000

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1085,6 +1085,15 @@ def user():
 
 
 @pytest.fixture
+def connect_auth_header():
+    """Connect-Auth header for the user fixture ('SU-295-689-628', 'Neri')"""
+    return (
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1Ijp7Im9pZCI6IlNVLTI5NS02ODktN"
+        "jI4IiwibmFtZSI6Ik5lcmkifX0.U_T6vuXnD293hcWNTJZ9QBViteNv8JXUL2gM0BezQ-k"
+    )
+
+
+@pytest.fixture
 def configuration_json():
     with open('./tests/fixtures/configuration.json') as json_file:
         return json.load(json_file)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -131,7 +131,7 @@ def test_create_ppr_base_on_user_uploaded_file(
     )
 
     new_ppr, _, _ = create_ppr(
-        ppr_data, common_context, deployment, dbsession, connect_client, logger,
+        ppr_data, common_context.user_id, deployment, dbsession, connect_client, logger,
     )
 
     assert new_ppr.id
@@ -166,7 +166,7 @@ def test_create_ppr_base_on_user_uploaded_file_with_errors(
     )
 
     new_ppr, _, _ = create_ppr(
-        ppr_data, common_context, deployment, dbsession, connect_client, logger,
+        ppr_data, common_context.user_id, deployment, dbsession, connect_client, logger,
     )
 
     assert new_ppr.id
@@ -222,7 +222,7 @@ def test_create_ppr_base_on_another_ppr_version_w_config(
     )
 
     new_ppr, _, _ = create_ppr(
-        ppr_data, common_context, deployment, dbsession, connect_client, logger,
+        ppr_data, common_context.user_id, deployment, dbsession, connect_client, logger,
     )
 
     assert new_ppr.id
@@ -279,7 +279,7 @@ def test_create_ppr_base_on_another_ppr_version_wo_config(
     )
 
     new_ppr, _, _ = create_ppr(
-        ppr_data, common_context, deployment, dbsession, connect_client, logger,
+        ppr_data, common_context.user_id, deployment, dbsession, connect_client, logger,
     )
 
     assert new_ppr.id
@@ -335,7 +335,7 @@ def test_create_ppr_wo_ppr_version_w_config(
     )
 
     new_ppr, _, _ = create_ppr(
-        ppr_data, common_context, deployment, dbsession, connect_client, logger,
+        ppr_data, common_context.user_id, deployment, dbsession, connect_client, logger,
     )
 
     assert new_ppr.id
@@ -376,7 +376,7 @@ def test_create_ppr_db_error(
 
     with pytest.raises(ClientError) as ex:
         create_ppr(
-            ppr_data, common_context, deployment,
+            ppr_data, common_context.user_id, deployment,
             dbsession, connect_client, logger,
         )
     assert ex.value.message == (


### PR DESCRIPTION
* PPRVersion.created_by field filled with user OID now
* Refactor create_ppr function. Use user_id instead of context.user_id
* Make a fixture for connect-auth header for the user, that is already fixtured