### PR TITLE
LITE-28892 Fix PPR changes for Delegate to L2

### DIFF
--- a/connect_ext_ppr/tasks_manager.py
+++ b/connect_ext_ppr/tasks_manager.py
@@ -37,7 +37,7 @@ from connect_ext_ppr.utils import (
     get_mps_to_update_for_apply_ppr_and_delegate_to_marketplaces,
     get_ppr_from_media,
     process_ppr_file_for_apply_ppr_and_delegate_to_marketplaces,
-    process_ppr_file_for_delelegate_l2,
+    process_ppr_file_for_delegate_l2,
 )
 
 
@@ -309,7 +309,7 @@ def delegate_to_l2(deployment_request, cbc_service, connect_client, logger, **kw
         file_name_template=PPR_FILE_NAME_DELEGATION_L2,
         deployment_request=deployment_request,
         deployment=deployment,
-        process_func=process_ppr_file_for_delelegate_l2,
+        process_func=process_ppr_file_for_delegate_l2,
     )
 
     tracking_id = _send_ppr(cbc_service, file)

--- a/connect_ext_ppr/utils.py
+++ b/connect_ext_ppr/utils.py
@@ -656,11 +656,11 @@ def get_file_size(file_obj):
     return file_size
 
 
-def process_ppr_file_for_delelegate_l2(sheet_name, ws):
-    if sheet_name == 'OpUnitServicePlans':
+def process_ppr_file_for_delegate_l2(sheet_name, ws):
+    if sheet_name == 'ServicePlans':
         ws['Published'] = 'TRUE'
-    elif sheet_name == 'ServicePlans':
-        ws['Published'] = 'FALSE'
+    elif sheet_name == 'OpUnitServicePlans':
+        ws['Published'] = 'TRUE'
 
 
 def execute_with_retry(function, exception_class, args=None, kwargs=None, num_retries=5):

--- a/tests/test_tasks_manager.py
+++ b/tests/test_tasks_manager.py
@@ -791,7 +791,7 @@ def test_delegate_to_l2(
     ppr_file_arg = send_ppr_mock.call_args.args[1]
     assert isinstance(ppr_file_arg, BufferedReader)
     assert check_excel_file_column_values(file_sent, 'OpUnitServicePlans', 'Published', [True] * 6)
-    assert check_excel_file_column_values(file_sent, 'ServicePlans', 'Published', [False] * 6)
+    assert check_excel_file_column_values(file_sent, 'ServicePlans', 'Published', [True] * 6)
 
 
 @patch.object(CBCService, '__init__')
@@ -852,7 +852,7 @@ def test_delegate_to_l2_processing_error(
         return_value=ppr_file_data,
     )
     process_ppr_file_for_delelegate_l2_mock = mocker.patch(
-        'connect_ext_ppr.tasks_manager.process_ppr_file_for_delelegate_l2',
+        'connect_ext_ppr.tasks_manager.process_ppr_file_for_delegate_l2',
         side_effect=ValueError('Wrong value "Cthulhu"'),
     )
     create_ppr_to_media_mock = mocker.patch(


### PR DESCRIPTION
Changed the PPR file process logic for Delegate to L2 task after discussion with Elmira.
So now in the ServicePlans sheet we set Published=True.