### PR TITLE
[DON'T MERGE] LITE-29320 LITE-29322 Draft for XVS extension enhanced filtering and …

### DIFF
--- a/connect_ext_ppr/filters.py
+++ b/connect_ext_ppr/filters.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 
 
-from pydantic import BaseModel
+from pydantic import BaseModel, validator
 from fastapi_filter import FilterDepends, with_prefix
 from fastapi_filter.contrib.sqlalchemy import Filter
 
@@ -9,44 +9,121 @@ from connect_ext_ppr.models.deployment import (
     Deployment, DeploymentRequest, MarketplaceConfiguration,
 )
 from connect_ext_ppr.models.ppr import PPRVersion
+from connect_ext_ppr.models.replicas import Product, Account
 from connect_ext_ppr.models.task import Task
 
 
+# TODO: Make mixin
+def restrict_sortable_fields_base(value, allowed_field_names):
+    if value is None:
+        return None
+
+    for field_name in value:
+        field_name = field_name.replace("+", "").replace("-", "")  #
+
+        if field_name not in allowed_field_names:
+            raise ValueError(f"You may only sort by: {', '.join(allowed_field_names)}")
+
+    return value
+
+
+class ProductFilter(Filter):
+    name: Optional[str]
+    name__ilike: Optional[str]
+
+    class Constants(Filter.Constants):
+        model = Product
+
+
+class VendorFilter(Filter):
+    name: Optional[str]
+    name__ilike: Optional[str]
+
+    class Constants(Filter.Constants):
+        model = Account
+
+
 class DeploymentFilter(Filter):
+    id: Optional[str]
     hub_id: Optional[str]
+    hub__name: Optional[str]  # custom filter
+    hub__name__like: Optional[str]  # custom filter
     product_id: Optional[str]
+    product: Optional[ProductFilter] = FilterDepends(with_prefix('product', ProductFilter))
     status: Optional[str]
     vendor_id: Optional[str]
+    vendor: Optional[VendorFilter] = FilterDepends(with_prefix('vendor', VendorFilter))
+
+    order_by: Optional[list[str]]
+    custom_order_by: Optional[str]
+
+    @validator("order_by")
+    @classmethod
+    def restrict_sortable_fields(cls, value):
+        return restrict_sortable_fields_base(value, ['id', 'product_id'])
+
+    @validator("hub__name", "hub__name__like", "custom_order_by")
+    @classmethod
+    def validate_hub_name(cls, value):
+        pass
 
     class Constants(Filter.Constants):
         model = Deployment
 
 
 class PPRVersionFilter(Filter):
-    id: Optional[str]
     version: Optional[int]
+    status: Optional[str]
+    description: Optional[str]
+    description__ilike: Optional[str]
 
     order_by: Optional[List[str]]
+
+    @validator("order_by")
+    @classmethod
+    def restrict_sortable_fields(cls, value):
+        return restrict_sortable_fields_base(value, ['version'])
 
     class Constants(Filter.Constants):
         model = PPRVersion
 
 
 class DeploymentRequestFilter(Filter):
-    status: Optional[str]
-    delegate_l2: Optional[bool]
-
+    """For specific deployment"""
+    id: Optional[str]
+    manually: Optional[bool]
     ppr: Optional[PPRVersionFilter] = FilterDepends(with_prefix('ppr', PPRVersionFilter))
+    status: Optional[str]
 
     order_by: Optional[List[str]]
+
+    @validator("order_by")
+    @classmethod
+    def restrict_sortable_fields(cls, value):
+        return restrict_sortable_fields_base(value, ['id'])
 
     class Constants(Filter.Constants):
         model = DeploymentRequest
 
 
+class DeploymentRequestExtendedFilter(DeploymentRequestFilter):
+    """For all deployments"""
+    delegate_l2: Optional[bool]
+
+    deployment_id: Optional[str]
+    deployment: Optional[DeploymentFilter] = FilterDepends(
+        with_prefix('deployment', DeploymentFilter),
+    )
+
+    @validator("order_by")
+    @classmethod
+    def restrict_sortable_fields(cls, value):
+        return restrict_sortable_fields_base(value, ['id', 'deployment_id'])
+
+
 class MarketplaceConfigurationFilter(Filter):
+    """For specific DeploymentRequest"""
     marketplace: Optional[str]
-    ppr: Optional[PPRVersionFilter] = FilterDepends(with_prefix('ppr', PPRVersionFilter))
 
     order_by: Optional[List[str]]
 
@@ -54,15 +131,9 @@ class MarketplaceConfigurationFilter(Filter):
         model = MarketplaceConfiguration
 
 
-class DeploymentRequestExtendedFilter(DeploymentRequestFilter):
-    id: Optional[str]
-
-    deployment: Optional[DeploymentFilter] = FilterDepends(
-        with_prefix('deployment', DeploymentFilter),
-    )
-
-    class Constants(Filter.Constants):
-        model = DeploymentRequest
+class MarketplaceConfigurationExtendedFilter(MarketplaceConfigurationFilter):
+    """For Deployment"""
+    ppr: Optional[PPRVersionFilter] = FilterDepends(with_prefix('ppr', PPRVersionFilter))
 
 
 class PricingBatchFilter(BaseModel):
@@ -70,7 +141,15 @@ class PricingBatchFilter(BaseModel):
 
 
 class TaskFilter(Filter):
+    id: Optional[str]
     status: Optional[str]
+
+    order_by: Optional[List[str]]
+
+    @validator("order_by")
+    @classmethod
+    def restrict_sortable_fields(cls, value):
+        return restrict_sortable_fields_base(value, ['id'])
 
     class Constants(Filter.Constants):
         model = Task


### PR DESCRIPTION
…sort

Just an example of implementation filtering and sort using fastapi-filter library, combined with some custom cases to estimate, how to move further.
Custom filters and sort in this example were implemented for the DeploymentFilter.

### Why do we have these special cases
Filtering.
There are some fields we want to filter by, but they are not stored in the model (e.g. hub), so we request them from the Connect on every call. And fastapi-filter supports filtering only by model fields. We may decide to store them, but in this case we will need to follow all the changes with such objects and process them (add more events).

Ordering.
fastapi-filter library doesn't support sort by related fields (https://github.com/arthurio/fastapi-filter/blob/main/fastapi_filter/base/filter.py#L35). So there is no way to sort by product__name, e.g.

### The further possible ways are the following:
1. Implement only filtering and sort by fields, that fastapi-filter allows us to (marked green here https://confluence.int.zone/display/CONNECT/XVS+extension+filtering+and+pagination+enhancement#XVSextensionfilteringandpaginationenhancement-Listoffieldstofilterby). Also there is a possibility to use sort by id instead of sort by name, not so convenient, but still useful.

2. Combine fastapi-filter with custom filtering and sort (like done in the PR for Deployment model). Looks like mess.

3. Make all the filtering and sort custom (remove fastapi-filter lib). Probably it will be more convenient to write own reusable functions or classes for filtering, appropriate for our cases.

4. Enhance the way we process custom cases. Likely it means to create own Filter class and to override its methods.

Personally I prefer to go 1st way. And if it won't be sufficient, discuss the list of required fields and come up with how to deal with them (maybe, for few fields it might fine to process them in a custom way). If we for sure need comprehensive solution, probably 3rd or 4th way is for us, need to investigate more.